### PR TITLE
Compile source to es5 using Babel

### DIFF
--- a/lib/affineFit.js
+++ b/lib/affineFit.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var gaussJordan = require('./gaussJordan');
+var transformation = require('./transformation');
+
+function emptyArray(x, y) {
+  return Array(y).fill(0).map(function () {
+    return Array(x).fill(0);
+  });
+}
+
+/**
+ * @param {array} q - from points
+ * @param {array} p - to points
+ */
+function affineFit(q, p) {
+  if (q.length !== p.length || q.length < 1) {
+    console.error('from_pts and to_pts must be of same size.');
+    return false;
+  }
+
+  var dim = q[0].length; // num of dimensions
+
+  if (q.length < dim) {
+    console.error('Too few points => under-determined system.');
+    return false;
+  }
+
+  // Make an empty (dim) x (dim+1) matrix and fill it
+  var c = emptyArray(dim, dim + 1);
+
+  for (var j = 0; j < dim; j++) {
+    for (var k = 0; k < dim + 1; k++) {
+      for (var i = 0; i < q.length; i++) {
+        var qt = q[i].concat(1);
+        c[k][j] += qt[k] * p[i][j];
+      }
+    }
+  }
+
+  // Make an empty (dim+1) x (dim+1) matrix and fill it
+  var Q = emptyArray(dim + 1, dim + 1);
+
+  q.forEach(function (qi) {
+    var qt = qi.concat(1);
+    for (var _i = 0; _i < dim + 1; _i++) {
+      for (var _j = 0; _j < dim + 1; _j++) {
+        Q[_i][_j] += qt[_i] * qt[_j];
+      }
+    }
+  });
+
+  // Augment Q with c and solve Q * a' = c by Gauss-Jordan
+  var M = Q.map(function (qi, idx) {
+    return qi.concat(c[idx]);
+  });
+
+  if (!gaussJordan(M)) {
+    console.error('Error: singular matrix. Points are probably coplanar.');
+    return false;
+  }
+
+  return transformation(M, dim);
+}
+module.exports = affineFit;

--- a/lib/gaussJordan.js
+++ b/lib/gaussJordan.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/*
+   Puts given matrix (2D array) into the Reduced Row Echelon Form.
+   Returns True if successful, False if 'm' is singular.
+   NOTE: make sure all the matrix items support fractions! Int matrix will NOT work!
+   Written by Jarno Elonen in April 2005, released into Public Domain
+
+   Ultra simple linear system solver. Replace this if you need speed.
+*/
+
+function gaussJordan(m) {
+  var eps = 1e-10; // 1.0 / Math.pow(10, 10)
+
+  var h = m.length;
+  var w = m[0].length;
+  var c;
+
+  for (var y = 0; y < h; y++) {
+    var maxrow = y;
+    for (var y2 = y + 1; y2 < h; y2++) {
+      // Find max pivot
+      if (Math.abs(m[y2][y]) > Math.abs(m[maxrow][y])) {
+        maxrow = y2;
+      }
+    }
+
+    c = m[maxrow];
+    m[maxrow] = m[y];
+    m[y] = c;
+
+    if (Math.abs(m[y][y]) <= eps) {
+      // Singular?
+      return false;
+    }
+
+    for (var _y = y + 1; _y < h; _y++) {
+      // Eliminate column y
+      c = m[_y][y] / m[y][y];
+      for (var x = y; x < w; x++) {
+        m[_y][x] -= m[y][x] * c;
+      }
+    }
+  }
+
+  for (var _y2 = h - 1; _y2 > -1; _y2--) {
+    // Backsubstitute
+    c = m[_y2][_y2];
+    for (var _y3 = 0; _y3 < _y2; _y3++) {
+      for (var _x = w - 1; _x > _y2 - 1; _x--) {
+        m[_y3][_x] -= m[_y2][_x] * m[_y3][_y2] / c;
+      }
+    }
+    m[_y2][_y2] /= c;
+    for (var _x2 = h; _x2 < w; _x2++) {
+      // Normalize row y
+      m[_y2][_x2] /= c;
+    }
+  }
+  return true;
+}
+module.exports = gaussJordan;

--- a/lib/transformation.js
+++ b/lib/transformation.js
@@ -1,0 +1,18 @@
+'use strict';
+
+function transformation(M, dim) {
+  function transformPoint(pt) {
+    var res = Array(dim).fill(0);
+
+    for (var j = 0; j < dim; j++) {
+      for (var i = 0; i < dim; i++) {
+        res[j] += pt[i] * M[i][j + dim + 1];
+      }
+      res[j] += M[dim][j + dim + 1];
+    }
+    return res;
+  }
+  transformPoint.M = M;
+  return transformPoint;
+}
+module.exports = transformation;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "affinefit",
   "version": "1.0.1",
   "description": "Fit an affine transformation to given points",
-  "main": "src/affineFit.js",
+  "main": "lib/affineFit.js",
   "author": "commenthol <commenthol@gmail.com>",
   "maintainers": "commenthol <commenthol@gmail.com>",
   "license": "CC0-1.0",
@@ -11,6 +11,8 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "babel-cli": "^6.7.7",
+    "babel-preset-es2015": "^6.6.0",
     "eslint": "^2.8.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.1.0",
@@ -23,7 +25,8 @@
     "cover": "istanbul cover _mocha --report lcov --report text -- --reporter dot --check-leaks test/*.mocha.js",
     "readme": "markedpp --githubid -i README.md -o README.md",
     "lint": "eslint '**/*.js'",
-    "pack": "npm test && npm run lint && npm run readme && npm pack"
+    "pack": "npm test && npm run lint && npm run readme && npm pack",
+    "babel": "babel --presets=es2015 -d lib/ src/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Not all browsers support ES6 which makes the code of this library unusable in those browsers (because of the use of the [`const`](https://github.com/commenthol/affinefit/blob/44db71966b6587b52c10068b59c361fb7df8ac16/src/affineFit.js#L3) and [`let`](https://github.com/commenthol/affinefit/blob/44db71966b6587b52c10068b59c361fb7df8ac16/src/gaussJordan.js#L18) keywords). To fix the problem I added a command in npm scripts that uses [`babel`](https://babeljs.io/docs/usage/cli/) to compile all the code in `src` to ES5 and put it under `lib`.
